### PR TITLE
Use linewidth for ggplot line geoms

### DIFF
--- a/R/ggplots.R
+++ b/R/ggplots.R
@@ -59,12 +59,11 @@ ecdf_data <- function(actual, predicted){
 #' dnew <- tail(credit_woe, 10000)
 #'
 #' gg_model_roc(m)
-#' gg_model_roc(m, newdata = dnew, size = 2)
+#' gg_model_roc(m, newdata = dnew, linewidth = 2)
 #'
 #' gg_model_ecdf(m)
-#' gg_model_ecdf(m, newdata = dnew, size = 2)
+#' gg_model_ecdf(m, newdata = dnew, linewidth = 2)
 #'
-#' gg_model_dist(m)
 #' gg_model_dist(m, newdata = dnew, alpha = 0.4, color = "transparent")
 #'
 #' gg_model_calibration(m)
@@ -521,7 +520,7 @@ gg_model_calibration <- function(model, newdata = NULL,
     ggplot2::geom_smooth(
       alpha = alpha_smooth,
       color = color_smooth,
-      size  = size_smooth,
+      linewidth = size_smooth,
       ...)  +
 
     ggplot2::scale_x_continuous(limits = c(0, 1)) +
@@ -606,7 +605,7 @@ gg_woes <- function(woes,
 
         ggplot2::geom_line(
           ggplot2::aes(y = .data$var),
-          size = 1.2,
+          linewidth = 1.2,
           group = 1,
           color = color_line
         ) +
@@ -667,6 +666,3 @@ gg_woes <- function(woes,
 # library(patchwork)
 #
 # p1 + p2
-
-
-

--- a/man/gg_model_roc.Rd
+++ b/man/gg_model_roc.Rd
@@ -87,10 +87,10 @@ m <- featsel_stepforward(m, scale = 5, trace = 0)
 dnew <- tail(credit_woe, 10000)
 
 gg_model_roc(m)
-gg_model_roc(m, newdata = dnew, size = 2)
+gg_model_roc(m, newdata = dnew, linewidth = 2)
 
 gg_model_ecdf(m)
-gg_model_ecdf(m, newdata = dnew, size = 2)
+gg_model_ecdf(m, newdata = dnew, linewidth = 2)
 
 gg_model_dist(m)
 gg_model_dist(m, newdata = dnew, alpha = 0.4, color = "transparent")


### PR DESCRIPTION
## Summary

- Replace deprecated `size` usage with `linewidth` for line-based ggplot geoms.
- Update examples that pass line width through `...` to use `linewidth`.
- Keep the public `size_smooth` argument name for compatibility, but pass it to `geom_smooth(linewidth = ...)` internally.

## Why

ggplot2 3.4.0 deprecated the `size` aesthetic for lines. This removes warnings like:

`Using size aesthetic for lines was deprecated in ggplot2 3.4.0. Please use linewidth instead.`

## Scope

Small compatibility fix only. No model logic changes.