### PR TITLE
Update pkgdown workflow runner

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -4,24 +4,24 @@ on:
       - main
       - master
     tags:
-      -'*'
+      - '*'
 
 name: pkgdown
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
-      RSPM: https://packagemanager.rstudio.com/cran/__linux__/bionic/latest
+      RSPM: https://packagemanager.posit.co/cran/__linux__/jammy/latest
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@v2
         id: install-r
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Install pak and query dependencies
         run: |
@@ -30,13 +30,13 @@ jobs:
         shell: Rscript {0}
 
       - name: Restore R package cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ${{ env.R_LIBS_USER }}/*
             !${{ env.R_LIBS_USER }}/pak
-          key: ubuntu-18.04-${{ steps.install-r.outputs.installed-r-version }}-1-${{ hashFiles('.github/r-depends.rds') }}
-          restore-keys: ubuntu-18.04-${{ steps.install-r.outputs.installed-r-version }}-1-
+          key: ubuntu-latest-${{ steps.install-r.outputs.installed-r-version }}-1-${{ hashFiles('.github/r-depends.rds') }}
+          restore-keys: ubuntu-latest-${{ steps.install-r.outputs.installed-r-version }}-1-
 
       - name: Install system dependencies
         if: runner.os == 'Linux'
@@ -44,18 +44,18 @@ jobs:
           pak::local_system_requirements(execute = TRUE)
           pak::pkg_system_requirements("pkgdown", execute = TRUE)
           pak::local_install_dev_deps(upgrade = TRUE, dependencies = c("all", "Config/Needs/website"))
-          pak::pkg_install("pkgdown")          
+          pak::pkg_install("pkgdown")
         shell: Rscript {0}
 
       - name: Install package
         run: R CMD INSTALL .
 
       - name: Build site
-        run: pkgdown::build_site()          
+        run: pkgdown::build_site()
         shell: Rscript {0}
-        
+
       - name: Deploy package
         run: |
           git config --local user.name "$GITHUB_ACTOR"
           git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'      
+          Rscript -e 'pkgdown::deploy_to_branch(new_process = FALSE)'


### PR DESCRIPTION
## Summary

- Move pkgdown from `ubuntu-18.04` to `ubuntu-latest`.
- Update GitHub Actions versions: checkout, setup-r, setup-pandoc, and cache.
- Update RSPM from the old `bionic` endpoint to the current Posit Package Manager `jammy` endpoint.
- Fix tag glob spacing from `-'*'` to `- '*'`.

## Why

The current pkgdown job waits for `ubuntu-18.04`, which is no longer available on GitHub-hosted runners. That is why the job stays waiting for a runner instead of starting.

## Scope

Workflow-only change. No R package code changes.